### PR TITLE
Sync the WalletDeposit size usage according to definition

### DIFF
--- a/src/ftx_exchange.rs
+++ b/src/ftx_exchange.rs
@@ -98,7 +98,7 @@ impl ExchangeClient for FtxExchangeClient {
                     if let Some(tx_id) = wd.txid {
                         return Some(DepositInfo {
                             tx_id,
-                            amount: wd.size.to_f64().unwrap(),
+                            amount: wd.size.unwrap().to_f64().unwrap(),
                         });
                     }
                 }


### PR DESCRIPTION
WalletDeposit size field type was changed to Option<Decimal> in the
ftx package.

This change depends on https://github.com/mvines/ftx/pull/1
Cargo.toml need to be updated to use a new revision of the ftx package, once the above PR is merged.