### PR TITLE
Jupiter Aggregator integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1725,6 +1725,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "jup-ag"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa30639a9737e8ed522ebc9e2b6fa33f96869bb50f8e94abe4d24aa1c3d1ed63"
+dependencies = [
+ "base64 0.13.0",
+ "bincode",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "solana-sdk",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3941,6 +3957,7 @@ dependencies = [
  "fd-lock",
  "ftx",
  "itertools",
+ "jup-ag",
  "pickledb",
  "reqwest",
  "rust_decimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 async-recursion = "1.0.0"
 async-trait = "0.1.50"
-bincode = "1.3.3"
+bincode = "1.3"
 chrono = "0.4"
 chrono-humanize = "0.2.1"
 clap = "2.33"
@@ -16,6 +16,8 @@ console = "0.14.1"
 rust_decimal = "1.23"
 rust_decimal_macros = "1.23"
 fd-lock = "3.0.0"
+jup-ag = "0.2.2"
+#jup-ag = { path = "../jup_ag" }
 #ftx = { git = "https://github.com/fabianboesiger/ftx", rev = "ce576c74f11c1795eef8cd101735166cb77b7892" }
 ftx = { git = "https://github.com/mvines/ftx", rev = "eea60b98cc47052dc0e6c42efe861d8d7cf6fb7f" }
 #ftx = { path = "../ftx" }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@ The intended audience for this program is:
 1. Solana Validators that need to track voting and transaction fee/rent rewards
 2. Solana Stakers that need to track staking rewards
 
-This program does not attempt to be a general purpose crypto trading tracker. It's assumed that once you sell your SOL for USD on an exchange of your choice, you'd switch to other existing solutions for further trading/transactions.
+This program does not attempt to be a general purpose crypto trading tracker.
+It's assumed that once you sell your SOL for USD on an exchange of your choice,
+you'd switch to other existing solutions for further trading/transactions. That
+being said, the latest iterations of `sys` include support for Tulip and Jupiter
+Aggregator for when you're not quite ready to part with your SOL yet.
 
 ## Quick Start
 1. Install Rust from https://rustup.rs/
@@ -18,14 +22,15 @@ You can also run `./fetch-release.sh` to download the latest Linux and macOS bin
   * Fetch market info, SOL balance and sell order status
   * Deposit from a vote, stake or system account
   * Initiate and cancel basic limit orders
+* Tulip USDC, SOL and mSOL lending integration
+* Jupiter Aggregator token swaps
 * Automatic epoch reward tracking for vote and stake accounts
 * Validator identity rewards are also automatically tracked at the epoch level, but not directly attributed to each individual block that rewards are credited
-* Lot management for all tracked accounts, through the disposal of SOL via an exchange sell order
-* A _sweep stake account_ system, whereby vote account rewards can be automatically sweeped into a stake account and staked as quickly as possible
-* Historical and spot price via CoinGecko
+* Lot management for all tracked accounts, with income and long/short capital gain/loss tracking suitable for tax prep purposes
+* A _sweep stake account_ system, whereby vote account rewards can be automatically swept into a stake account and staked as quickly as possible
+* Historical and spot price via CoinGecko for SOL and supported tokens.
 * Data is contained in a local `sell-your-sol/` subdirectory that can be easily backed up, and is editable by hand if necessary
 * Excel export
-* Tulip USDC, SOL and mSOL lending integration
 
 ## Examples
 _TODO..._


### PR DESCRIPTION
Add v1 jup.ag subcommands to swap between supported tokens (wSOL, mSOL, USDC) without hitting a CEX.

```
$ sys jup quote --help
sys-jup-quote 
Get swap quotes

USAGE:
    sys jup quote [FLAGS] [OPTIONS] <SOURCE TOKEN> <DESTINATION TOKEN> <AMOUNT>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information
    -v, --verbose    Show additional information

OPTIONS:
        --db-path <PATH>        Database path [default: sell-your-sol]
    -u, --url <URL>             JSON RPC URL for the cluster [default: https://api.mainnet-beta.solana.com]
        --slippage <PERCENT>    Maximum slippage percent [default: 1]

ARGS:
    <SOURCE TOKEN>         Source token [default: wSOL]
    <DESTINATION TOKEN>    Destination token [default: USDC]
    <AMOUNT>               Amount of the source token to swap [default: 1]
```
```
$ sys jup swap --help
sys-jup-swap 
Swap tokens

USAGE:
    sys jup swap [FLAGS] [OPTIONS] <KEYPAIR> <SOURCE TOKEN> <DESTINATION TOKEN> <SOURCE TOKEN AMOUNT>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information
    -v, --verbose    Show additional information

OPTIONS:
        --db-path <PATH>        Database path [default: sell-your-sol]
    -u, --url <URL>             JSON RPC URL for the cluster [default: https://api.mainnet-beta.solana.com]
        --slippage <PERCENT>    Maximum slippage percent [default: 1]

ARGS:
    <KEYPAIR>                Address of the account holding the tokens to swap
    <SOURCE TOKEN>           Source token
    <DESTINATION TOKEN>      Destination token
    <SOURCE TOKEN AMOUNT>    Amount of tokens to swap
```