### PR TITLE
Add coingecko current price cache

### DIFF
--- a/src/coin_gecko.rs
+++ b/src/coin_gecko.rs
@@ -49,70 +49,79 @@ fn token_to_coin(token: &MaybeToken) -> Result<&'static str, Box<dyn std::error:
 }
 
 pub async fn get_current_price(token: &MaybeToken) -> Result<Decimal, Box<dyn std::error::Error>> {
-    let coin = token_to_coin(token)?;
-    let url = format!("https://api.coingecko.com/api/v3/simple/price?ids={coin}&vs_currencies=usd");
-
-    #[derive(Debug, Serialize, Deserialize)]
-    struct Coins {
-        solana: Option<CurrencyList>,
-        msol: Option<CurrencyList>,
-        #[serde(rename = "lido-staked-sol")]
-        stsol: Option<CurrencyList>,
+    type CurrentPriceCache = HashMap<MaybeToken, Decimal>;
+    lazy_static::lazy_static! {
+        static ref CURRENT_PRICE_CACHE: Arc<RwLock<CurrentPriceCache>> = Arc::new(RwLock::new(HashMap::new()));
     }
+    let mut current_price_cache = CURRENT_PRICE_CACHE.write().await;
 
-    let coins = reqwest::get(url).await?.json::<Coins>().await?;
+    match current_price_cache.get(token) {
+        Some(price) => Ok(*price),
+        None => {
+            let coin = token_to_coin(token)?;
+            let url = format!(
+                "https://api.coingecko.com/api/v3/simple/price?ids={coin}&vs_currencies=usd"
+            );
 
-    coins
-        .solana
-        .or(coins.msol)
-        .or(coins.stsol)
-        .ok_or_else(|| format!("Simple price data not available for {coin}").into())
-        .map(|price| Decimal::from_f64(price.usd).unwrap())
+            #[derive(Debug, Serialize, Deserialize)]
+            struct Coins {
+                solana: Option<CurrencyList>,
+                msol: Option<CurrencyList>,
+                #[serde(rename = "lido-staked-sol")]
+                stsol: Option<CurrencyList>,
+            }
+
+            let coins = dbg!(reqwest::get(url).await?.json::<Coins>().await?);
+
+            coins
+                .solana
+                .or(coins.msol)
+                .or(coins.stsol)
+                .ok_or_else(|| format!("Simple price data not available for {coin}").into())
+                .map(|price| {
+                    let price = Decimal::from_f64(price.usd).unwrap();
+                    current_price_cache.insert(*token, price);
+                    price
+                })
+        }
+    }
 }
 
 pub async fn get_historical_price(
     when: NaiveDate,
     token: &MaybeToken,
 ) -> Result<Decimal, Box<dyn std::error::Error>> {
-    type Data = HashMap<(NaiveDate, String), Decimal>;
+    type HistoricalPriceCache = HashMap<(NaiveDate, MaybeToken), Decimal>;
     lazy_static::lazy_static! {
-        static ref PRICE_CACHE: Arc<RwLock<Data>> = Arc::new(RwLock::new(HashMap::new()));
+        static ref HISTORICAL_PRICE_CACHE: Arc<RwLock<HistoricalPriceCache>> = Arc::new(RwLock::new(HashMap::new()));
     }
+    let mut historical_price_cache = HISTORICAL_PRICE_CACHE.write().await;
 
-    let coin = token_to_coin(token)?;
+    let price_cache_key = (when, *token);
 
-    if let Ok(pc) = PRICE_CACHE.try_read() {
-        let key = (when, coin.to_string());
-        if pc.contains_key(&key) {
-            return pc
-                .get(&key)
-                .ok_or_else(|| format!("Cache is invalid for {when}").into())
-                .copied();
+    match historical_price_cache.get(&price_cache_key) {
+        Some(price) => Ok(*price),
+        None => {
+            let coin = token_to_coin(token)?;
+            let url = format!(
+                "https://api.coingecko.com/api/v3/coins/{}/history?date={}-{}-{}&localization=false",
+                coin,
+                when.day(),
+                when.month(),
+                when.year()
+            );
+
+            reqwest::get(url)
+                .await?
+                .json::<HistoryResponse>()
+                .await?
+                .market_data
+                .ok_or_else(|| format!("Market data not available for {coin} on {when}").into())
+                .map(|market_data| {
+                    let price = Decimal::from_f64(market_data.current_price.usd).unwrap();
+                    historical_price_cache.insert(price_cache_key, price);
+                    price
+                })
         }
-    }
-
-    let url = format!(
-        "https://api.coingecko.com/api/v3/coins/{}/history?date={}-{}-{}&localization=false",
-        coin,
-        when.day(),
-        when.month(),
-        when.year()
-    );
-
-    match reqwest::get(url)
-        .await?
-        .json::<HistoryResponse>()
-        .await?
-        .market_data
-    {
-        Some(market_data) => {
-            let price = market_data.current_price.usd;
-            PRICE_CACHE
-                .write()
-                .await
-                .insert((when, coin.to_string()), Decimal::from_f64(price).unwrap());
-            Ok(Decimal::from_f64(price).unwrap())
-        }
-        None => Err(format!("Market data not available for {when}").into()),
     }
 }


### PR DESCRIPTION
As a follow-up to #7, wrap a cache around coin gecko current price requests to further avoid getting rate limited