### PR TITLE
Add organization to influxdb configuration

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4314,6 +4314,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 .help("Access Token"),
                         )
                         .arg(
+                            Arg::with_name("org")
+                                .value_name("ORG")
+                                .takes_value(true)
+                                .required(true)
+                                .help("Organization"),
+                        )
+                        .arg(
                             Arg::with_name("bucket")
                                 .value_name("BUCKET")
                                 .takes_value(true)
@@ -5786,10 +5793,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 Some(MetricsConfig {
                     url,
                     token: _,
+                    org,
                     bucket,
                 }) => {
                     println!("Url: {url}");
                     println!("Token: ********");
+                    println!("Organization: {org}");
                     println!("Bucket: {bucket}");
                 }
             },
@@ -5797,6 +5806,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 db.set_metrics_config(MetricsConfig {
                     url: value_t_or_exit!(arg_matches, "url", String),
                     token: value_t_or_exit!(arg_matches, "token", String),
+                    org: value_t_or_exit!(arg_matches, "org", String),
                     bucket: value_t_or_exit!(arg_matches, "bucket", String),
                 })?;
                 println!("InfluxDb configuration set");

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -15,6 +15,7 @@ lazy_static::lazy_static! {
 pub struct MetricsConfig {
     pub url: String,
     pub token: String,
+    pub org: String,
     pub bucket: String,
 }
 
@@ -22,6 +23,7 @@ pub fn env_config() -> Option<MetricsConfig> {
     Some(MetricsConfig {
         url: env::var("INFLUX_URL").ok()?,
         token: env::var("INFLUX_API_TOKEN").ok()?,
+        org: env::var("INFLUX_ORG").ok()?,
         bucket: env::var("INFLUX_BUCKET")
             .ok()
             .unwrap_or_else(|| "sys".into()),
@@ -35,6 +37,7 @@ pub async fn push(point: Point) {
 pub async fn send(config: Option<MetricsConfig>) {
     if let Some(config) = config {
         let client = Client::new(config.url, config.token)
+            .with_org(config.org)
             .with_bucket(config.bucket)
             .with_precision(Precision::MS);
         //let client = client.insert_to_stdout();


### PR DESCRIPTION
InfluxDB seems to be requiring org parameter in request URLs. This PR adds the organization parameter to the InfluxDB configuration.