### PR TITLE
Move sys main to bin/ and rename

### DIFF
--- a/src/bin/sys.rs
+++ b/src/bin/sys.rs
@@ -1,11 +1,4 @@
-mod amount;
-mod db;
-mod field_as_string;
-mod get_transaction_balance_change;
-mod rpc_client_utils;
-
 use {
-    crate::{amount::Amount, get_transaction_balance_change::*},
     chrono::prelude::*,
     chrono_humanize::HumanTime,
     clap::{
@@ -44,7 +37,9 @@ use {
         time::Duration,
     },
     sys::{
+        amount::Amount,
         exchange::{self, *},
+        get_transaction_balance_change::*,
         metrics::{self, dp, MetricsConfig},
         notifier::*,
         priority_fee::{apply_priority_fee, PriorityFee},

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{field_as_string, metrics::MetricsConfig},
+    crate::{exchange::*, field_as_string, metrics::MetricsConfig, token::*},
     chrono::{prelude::*, NaiveDate},
     pickledb::{PickleDb, PickleDbDumpPolicy},
     rust_decimal::prelude::*,
@@ -17,7 +17,6 @@ use {
         time::{SystemTime, UNIX_EPOCH},
     },
     strum::{EnumString, IntoStaticStr},
-    sys::{exchange::*, token::*},
     thiserror::Error,
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,15 +11,20 @@ use {
     },
 };
 
+pub mod amount;
 pub mod binance_exchange;
 pub mod coin_gecko;
 pub mod coinbase_exchange;
+pub mod db;
 pub mod exchange;
+pub mod field_as_string;
+pub mod get_transaction_balance_change;
 pub mod helius_rpc;
 pub mod kraken_exchange;
 pub mod metrics;
 pub mod notifier;
 pub mod priority_fee;
+pub mod rpc_client_utils;
 pub mod token;
 pub mod vendor;
 


### PR DESCRIPTION
I'd like to use sys as a library from other applications, with main.rs being one of the apps using the library. This PR is a first step of refactoring sys to a library, moving main.rs to bin/ and renaming it to sys.rs.