### PR TITLE
Avoid panic when signing is cancelled

### DIFF
--- a/src/bin/sys.rs
+++ b/src/bin/sys.rs
@@ -3407,7 +3407,7 @@ async fn process_account_split<T: Signers>(
         into_keypair.pubkey(),
     );
 
-    transaction.partial_sign(&signers, recent_blockhash);
+    transaction.try_partial_sign(&signers, recent_blockhash)?;
     transaction.try_sign(&[&into_keypair], recent_blockhash)?;
 
     let signature = transaction.signatures[0];


### PR DESCRIPTION
It probably doesn’t matter in a cli app if it panics, but I’m using sys as a library in a GUI app and this panic on rejected signing crashes the app. There are a few other partial_sign calls in other process_* functions that I didn’t change, because I’m not yet calling them in my gui app, and I’m not sure about the original reasoning for why panic emitting partial_sign was used instead of the error-returning try_partial_sign version.