### PR TITLE
Use keyring to store exchange secrets in system store

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     - if: runner.os == 'Linux'
       run: |
         sudo apt-get update
-        sudo apt-get install -y libudev-dev
+        sudo apt-get install -y libudev-dev libdbus-1-dev pkg-config
 
     - uses: actions-rs/toolchain@v1
       with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2712,6 +2712,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1961983669d57bdfe6c0f3ef8e4c229b5ef751afcc7d87e4271d2f71f6ccfa8b"
+dependencies = [
+ "dbus-secret-service",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.2.0",
+]
+
+[[package]]
 name = "kraken_sdk_rest"
 version = "0.17.0"
 source = "git+https://github.com/mvines/kraken_sdk_rust?rev=80c634b3a8527f653db989689b298496dad30d4e#80c634b3a8527f653db989689b298496dad30d4e"
@@ -2738,6 +2750,15 @@ name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libredox"
@@ -2962,10 +2983,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
 dependencies = [
  "num-bigint 0.2.6",
- "num-complex",
+ "num-complex 0.2.4",
  "num-integer",
  "num-iter",
- "num-rational",
+ "num-rational 0.2.4",
+ "num-traits",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-complex 0.4.6",
+ "num-integer",
+ "num-iter",
+ "num-rational 0.4.2",
  "num-traits",
 ]
 
@@ -3008,6 +3043,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
 dependencies = [
  "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -3056,6 +3100,17 @@ checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
 dependencies = [
  "autocfg",
  "num-bigint 0.2.6",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
 ]
@@ -3260,7 +3315,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd23b938276f14057220b707937bcb42fa76dda7560e57a2da30cb52d557937"
 dependencies = [
- "num",
+ "num 0.2.1",
 ]
 
 [[package]]
@@ -7416,6 +7471,7 @@ dependencies = [
  "influxdb-client",
  "itertools 0.10.5",
  "jup-ag",
+ "keyring",
  "kraken_sdk_rest",
  "lazy_static",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,6 +1319,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
 
 [[package]]
+name = "dbus"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bb21987b9fb1613058ba3843121dd18b163b254d8a6e797e144cbac14d96d1b"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "winapi",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42a16374481d92aed73ae45b1f120207d8e71d24fb89f357fadbd8f946fd84b"
+dependencies = [
+ "dbus",
+ "futures-util",
+ "num 0.4.3",
+ "once_cell",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "der-parser"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ jup-ag = "0.9.1"
 #kraken_sdk_rest = { path = "../kraken_sdk_rust/kraken_sdk_rest" }
 kraken_sdk_rest = { git = "https://github.com/mvines/kraken_sdk_rust", rev = "80c634b3a8527f653db989689b298496dad30d4e" }
 #kraken_sdk_rest = "0.18.0"
+keyring = { version = "3", features = ["apple-native", "sync-secret-service"] }
 lazy_static = "1.4.0"
 log = "0.4.17"
 num-derive = "0.4"

--- a/src/coinbase_exchange.rs
+++ b/src/coinbase_exchange.rs
@@ -21,6 +21,9 @@ impl ExchangeClient for CoinbaseExchangeClient {
         pin_mut!(accounts);
 
         while let Some(account_result) = accounts.next().await {
+            if let Err(e) = account_result {
+                return Err(format!("Failed to get accounts: {e}").into());
+            }
             for account in account_result.unwrap() {
                 if let Ok(id) = coinbase_rs::Uuid::from_str(&account.id) {
                     if token.name() == account.currency.code
@@ -157,6 +160,7 @@ pub fn new(
     }: ExchangeCredentials,
 ) -> Result<CoinbaseExchangeClient, Box<dyn std::error::Error>> {
     assert!(subaccount.is_none());
+    let secret = secret.replace("\\n", "\n");
     Ok(CoinbaseExchangeClient {
         client: coinbase_rs::Private::new(coinbase_rs::MAIN_URL, &api_key, &secret),
     })

--- a/src/db.rs
+++ b/src/db.rs
@@ -727,7 +727,7 @@ impl Db {
     ) -> DbResult<()> {
         let ec = serde_json::to_string(&exchange_credentials).unwrap();
         // user can't be an empty string
-        let user = format!("{}_{exchange_account}", exchange.to_string());
+        let user = format!("{exchange}_{exchange_account}");
         let keyring_entry = match keyring::Entry::new(&exchange.to_string(), &user) {
             Ok(entry) => entry,
             Err(e) => {
@@ -747,7 +747,7 @@ impl Db {
         exchange: Exchange,
         exchange_account: &str,
     ) -> Option<ExchangeCredentials> {
-        let user = format!("{}_{exchange_account}", exchange.to_string());
+        let user = format!("{exchange}_{exchange_account}");
         let keyring_entry = match keyring::Entry::new(&exchange.to_string(), &user) {
             Ok(entry) => entry,
             Err(e) => {
@@ -776,7 +776,7 @@ impl Db {
         exchange: Exchange,
         exchange_account: &str,
     ) -> DbResult<()> {
-        let user = format!("{}_{exchange_account}", exchange.to_string());
+        let user = format!("{exchange}_{exchange_account}");
         let keyring_entry = match keyring::Entry::new(&exchange.to_string(), &user) {
             Ok(entry) => entry,
             Err(e) => {

--- a/src/db.rs
+++ b/src/db.rs
@@ -767,7 +767,7 @@ impl Db {
             Err(e) => {
                 eprintln!("Failed to deserialize credentials: {e}");
                 None
-            },
+            }
         }
     }
 


### PR DESCRIPTION
It seems better to use encrypted storage for exchange sensitive data. Here’s an attempt to use keyring crate to interface with keychain on macos and secret-service on Linux.

What do you think?