### PR TITLE
Format date in coingecko request url as required DD-MM-YYYY

### DIFF
--- a/src/coin_gecko.rs
+++ b/src/coin_gecko.rs
@@ -177,7 +177,7 @@ pub async fn get_historical_price(
 
             let (maybe_pro, x_cg_pro_api_key) = get_cg_pro_api_key();
             let url = format!(
-                "https://{maybe_pro}api.coingecko.com/api/v3/coins/{}/history?date={}-{}-{}&localization=false{x_cg_pro_api_key}",
+                "https://{maybe_pro}api.coingecko.com/api/v3/coins/{}/history?date={:02}-{:02}-{:4}&localization=false{x_cg_pro_api_key}",
                 coin,
                 when.day(),
                 when.month(),

--- a/src/vendor/kamino/fraction.rs
+++ b/src/vendor/kamino/fraction.rs
@@ -294,6 +294,7 @@ impl TryFrom<U256> for U128 {
     }
 }
 
+#[allow(dead_code)]
 pub struct FractionDisplay<'a>(&'a Fraction);
 
 impl Display for FractionDisplay<'_> {


### PR DESCRIPTION
Coingecko now requires precise formatting of date in request url, as stated in this error message
"Invalid value provided for the date parameter. Use YYYY-MM-DD, DD-MM-YYYY or UNIX timestamp only."

This PR fixes the url format.