### PR TITLE
coin-gecko: Add user-agent to requests

### DIFF
--- a/src/coin_gecko.rs
+++ b/src/coin_gecko.rs
@@ -127,7 +127,8 @@ pub async fn get_current_price(token: &MaybeToken) -> Result<Decimal, Box<dyn st
                 pyusd: Option<CurrencyList>,
             }
 
-            let coins = reqwest::get(url).await?.json::<Coins>().await?;
+            let client = reqwest::Client::builder().user_agent("sys").build()?;
+            let coins = client.get(url).send().await?.json::<Coins>().await?;
 
             coins
                 .solana
@@ -184,7 +185,10 @@ pub async fn get_historical_price(
                 when.year()
             );
 
-            reqwest::get(url)
+            let client = reqwest::Client::builder().user_agent("sys").build()?;
+            client
+                .get(url)
+                .send()
                 .await?
                 .json::<HistoryResponse>()
                 .await?


### PR DESCRIPTION
#### Problem

The public Coin Gecko API isn't working with an error of:

```
{"status":{"error_code":403,"error_message":"Please add a descriptive User-Agent to your request. For higher rate limits & stable integration, please subscribe to our API plans: https://www.coingecko.com/en/api/pricing . If you think this is a mistake, please report here: https://forms.gle/3V2z8Mb3k2RMu5S2A"}}
```

#### Summary of changes

Add a user-agent of "sys" so the requests work.